### PR TITLE
feature: Add content_type field to Toot struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RasmusLindroth/go-mastodon
+module github.com/blacklight/go-mastodon
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// TODO: Rename this to github.com/RasmusLindroth/go-mastodon before merging PR
 module github.com/blacklight/go-mastodon
 
 go 1.16

--- a/mastodon.go
+++ b/mastodon.go
@@ -225,7 +225,8 @@ const (
 // Toot is a struct to post status.
 type Toot struct {
 	Status      string     `json:"status"`
-	InReplyToID ID         `json:"in_reply_to_id"`
+	InReplyToID *ID        `json:"in_reply_to_id"`
+	QuoteID     *ID        `json:"quote_id"`
 	MediaIDs    []ID       `json:"media_ids"`
 	Sensitive   bool       `json:"sensitive"`
 	SpoilerText string     `json:"spoiler_text"`
@@ -234,6 +235,7 @@ type Toot struct {
 	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
 	Poll        *TootPoll  `json:"poll"`
 	ContentType string     `json:"content_type,omitempty"`
+	To          []string   `json:"to,omitempty"`
 }
 
 // TootPoll holds information for creating a poll in Toot.

--- a/mastodon.go
+++ b/mastodon.go
@@ -233,6 +233,7 @@ type Toot struct {
 	Language    string     `json:"language"`
 	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
 	Poll        *TootPoll  `json:"poll"`
+	ContentType string     `json:"content_type,omitempty"`
 }
 
 // TootPoll holds information for creating a poll in Toot.

--- a/mastodon.go
+++ b/mastodon.go
@@ -225,7 +225,7 @@ const (
 // Toot is a struct to post status.
 type Toot struct {
 	Status      string     `json:"status"`
-	InReplyToID *ID        `json:"in_reply_to_id"`
+	InReplyToID ID         `json:"in_reply_to_id"`
 	QuoteID     *ID        `json:"quote_id"`
 	MediaIDs    []ID       `json:"media_ids"`
 	Sensitive   bool       `json:"sensitive"`
@@ -235,7 +235,6 @@ type Toot struct {
 	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
 	Poll        *TootPoll  `json:"poll"`
 	ContentType string     `json:"content_type,omitempty"`
-	To          []string   `json:"to,omitempty"`
 }
 
 // TootPoll holds information for creating a poll in Toot.

--- a/status.go
+++ b/status.go
@@ -422,8 +422,8 @@ func (c *Client) UpdateStatus(ctx context.Context, toot *Toot, id ID) (*Status, 
 func (c *Client) postStatus(ctx context.Context, toot *Toot, update bool, updateID ID) (*Status, error) {
 	params := url.Values{}
 	params.Set("status", toot.Status)
-	if toot.InReplyToID != "" {
-		params.Set("in_reply_to_id", string(toot.InReplyToID))
+	if toot.InReplyToID != nil {
+		params.Set("in_reply_to_id", string(*toot.InReplyToID))
 	}
 	if toot.MediaIDs != nil {
 		for _, media := range toot.MediaIDs {

--- a/status.go
+++ b/status.go
@@ -455,6 +455,9 @@ func (c *Client) postStatus(ctx context.Context, toot *Toot, update bool, update
 	if toot.SpoilerText != "" {
 		params.Set("spoiler_text", toot.SpoilerText)
 	}
+	if toot.QuoteID != nil {
+		params.Set("quote_id", string(*toot.QuoteID))
+	}
 	if toot.ContentType != "" {
 		params.Set("content_type", toot.ContentType)
 	}

--- a/status.go
+++ b/status.go
@@ -455,6 +455,9 @@ func (c *Client) postStatus(ctx context.Context, toot *Toot, update bool, update
 	if toot.SpoilerText != "" {
 		params.Set("spoiler_text", toot.SpoilerText)
 	}
+	if toot.ContentType != "" {
+		params.Set("content_type", toot.ContentType)
+	}
 
 	var status Status
 	var err error

--- a/status.go
+++ b/status.go
@@ -422,8 +422,8 @@ func (c *Client) UpdateStatus(ctx context.Context, toot *Toot, id ID) (*Status, 
 func (c *Client) postStatus(ctx context.Context, toot *Toot, update bool, updateID ID) (*Status, error) {
 	params := url.Values{}
 	params.Set("status", toot.Status)
-	if toot.InReplyToID != nil {
-		params.Set("in_reply_to_id", string(*toot.InReplyToID))
+	if toot.InReplyToID != "" {
+		params.Set("in_reply_to_id", string(toot.InReplyToID))
 	}
 	if toot.MediaIDs != nil {
 		for _, media := range toot.MediaIDs {


### PR DESCRIPTION
This commit introduces a new field, `ContentType`, to the Toot struct in mastodon.go.

This field is intended to store the MIME type of the content associated with a Toot, such as "text/plain", "text/html", or "text/markdown".

Creating Markdown posts is supported on Pleroma/Akkoma and some Mastodon forks.

This also adds the `QuoteId` field, supported by Pleroma/Akkoma as well as by recent versions of Mastodon.